### PR TITLE
Add 'InspiratioNULL' to the list of usernames

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -64,6 +64,7 @@
     "digitalby",
     "vdkdamian",
     "carlosdcl",
+    "InspiratioNULL",
     "ADD_NEW_GITHUB_USERNAMES_ABOVE_THIS_LINE"
   ],
   "message": "Thank you for your pull request and welcome to the Skip community. We require contributors to sign our [contributor license agreement (CLA)](https://github.com/skiptools/clabot-config/blob/main/Contributor-License-Agreement.md), and we don't seem to have the user(s) {{usersWithoutCLA}} on file. In order for us to review and merge your code, for each noted user ***please add your GitHub username to Skip's [.clabot](https://github.com/skiptools/clabot-config/edit/main/.clabot) file***",


### PR DESCRIPTION
Hello, signing this because I wanted to make a pull request on the homebrew repo due to the deprecated 'depends_on ventura' strings
Thank you for your work!