### PR TITLE
Add garthvh to CLA

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -70,6 +70,7 @@
     "paulober",
     "markiv",
     "jaredbrewer",
+    "garthvh",
     "ADD_NEW_GITHUB_USERNAMES_ABOVE_THIS_LINE"
   ],
   "message": "Thank you for your pull request and welcome to the Skip community. We require contributors to sign our [contributor license agreement (CLA)](https://github.com/skiptools/clabot-config/blob/main/Contributor-License-Agreement.md), and we don't seem to have the user(s) {{usersWithoutCLA}} on file. In order for us to review and merge your code, for each noted user ***please add your GitHub username to Skip's [.clabot](https://github.com/skiptools/clabot-config/edit/main/.clabot) file***",


### PR DESCRIPTION
Adding my GitHub username @garthvh to the .clabot file to sign the CLA for skiptools/skip-ui#477.