### PR TITLE
Add WiesnerPeti to .clabot

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -72,6 +72,7 @@
     "jaredbrewer",
     "garthvh",
     "mliem2k",
+    "WiesnerPeti",
     "ADD_NEW_GITHUB_USERNAMES_ABOVE_THIS_LINE"
   ],
   "message": "Thank you for your pull request and welcome to the Skip community. We require contributors to sign our [contributor license agreement (CLA)](https://github.com/skiptools/clabot-config/blob/main/Contributor-License-Agreement.md), and we don't seem to have the user(s) {{usersWithoutCLA}} on file. In order for us to review and merge your code, for each noted user ***please add your GitHub username to Skip's [.clabot](https://github.com/skiptools/clabot-config/edit/main/.clabot) file***",


### PR DESCRIPTION
Signing the Skip Contributor License Agreement by adding my GitHub username (@WiesnerPeti) to the `.clabot` file, as requested by cla-bot on skiptools/skip-android-bridge#31.

I am submitting my contribution as an individual copyright owner.