### PR TITLE
Add BPHvZ to the CLA signatories

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -73,6 +73,7 @@
     "garthvh",
     "mliem2k",
     "WiesnerPeti",
+    "BPHvZ",
     "ADD_NEW_GITHUB_USERNAMES_ABOVE_THIS_LINE"
   ],
   "message": "Thank you for your pull request and welcome to the Skip community. We require contributors to sign our [contributor license agreement (CLA)](https://github.com/skiptools/clabot-config/blob/main/Contributor-License-Agreement.md), and we don't seem to have the user(s) {{usersWithoutCLA}} on file. In order for us to review and merge your code, for each noted user ***please add your GitHub username to Skip's [.clabot](https://github.com/skiptools/clabot-config/edit/main/.clabot) file***",


### PR DESCRIPTION
I accept the Skip [Contributor License Agreement](https://github.com/skiptools/clabot-config/blob/main/Contributor-License-Agreement.md) and am adding my GitHub username to `.clabot` as instructed in the README.

This is in preparation for a PR against `skip-ui` fixing sheets not reacting to the soft keyboard on Android.

(Per the README, cla-bot is expected to report the CLA as unsigned on this PR itself — see skiptools/clabot-config#29.)