### PR TITLE
Add Aecasorg to the CLA contributors list

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -77,6 +77,7 @@
     "iyungui",
     "MarcHidalgo5",
     "GoodOlClint",
+    "Aecasorg",
     "ADD_NEW_GITHUB_USERNAMES_ABOVE_THIS_LINE"
   ],
   "message": "Thank you for your pull request and welcome to the Skip community. We require contributors to sign our [contributor license agreement (CLA)](https://github.com/skiptools/clabot-config/blob/main/Contributor-License-Agreement.md), and we don't seem to have the user(s) {{usersWithoutCLA}} on file. In order for us to review and merge your code, for each noted user ***please add your GitHub username to Skip's [.clabot](https://github.com/skiptools/clabot-config/edit/main/.clabot) file***",


### PR DESCRIPTION
Signing the CLA for https://github.com/skiptools/skip-ui/pull/499 (with employer approval, per the agreement's employment clause).